### PR TITLE
feat: enable interrupt mode via ctrl+n

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -14,6 +14,8 @@ This document lists the available keyboard shortcuts in the Gemini CLI.
 | `Ctrl+S` | Allows long responses to print fully, disabling truncation. Use your terminal's scrollback to view the entire output. |
 | `Ctrl+T` | Toggle the display of tool descriptions.                                                                              |
 | `Ctrl+Y` | Toggle auto-approval (YOLO mode) for all tool calls.                                                                  |
+| `Ctrl+N` | Enable interrupt mode. |
+        |
 
 ## Input Prompt
 

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -1056,4 +1056,28 @@ describe('App UI', () => {
       expect(validateAuthMethodSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe('interrupt mode', () => {
+    it('should enable interrupt mode with Ctrl+N', async () => {
+      const { stdin, lastFrame, unmount } = render(
+        <App
+          config={mockConfig as unknown as ServerConfig}
+          settings={mockSettings}
+          version={mockVersion}
+        />,
+      );
+      currentUnmount = unmount;
+
+      // Initially, interrupt mode should be disabled.
+      expect(vi.mocked(useGeminiStream).mock.calls.at(-1)?.[12]).toBe(false);
+
+      // Send Ctrl+N to enable interrupt mode.
+      stdin.write('\u000e');
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Verify that useGeminiStream is called with interrupt mode enabled
+      expect(vi.mocked(useGeminiStream).mock.calls.at(-1)?.[12]).toBe(true);
+      expect(lastFrame()).toContain('Interrupt mode enabled.');
+    });
+  });
 });

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -180,6 +180,9 @@ const App = ({
     IdeContext | undefined
   >();
   const [isProcessing, setIsProcessing] = useState<boolean>(false);
+  const [interruptModeEnabled, setInterruptModeEnabled] = useState(
+    interruptMode,
+  );
 
   useEffect(() => {
     const unsubscribe = ideContext.subscribeToIdeContext(setIdeContextState);
@@ -508,7 +511,7 @@ const App = ({
     performMemoryRefresh,
     modelSwitchedFromQuotaError,
     setModelSwitchedFromQuotaError,
-    interruptMode,
+    interruptModeEnabled,
   );
 
   // Input handling
@@ -598,6 +601,14 @@ const App = ({
         return;
       }
       handleExit(ctrlDPressedOnce, setCtrlDPressedOnce, ctrlDTimerRef);
+    } else if (key.ctrl && (input === 'n' || input === 'N')) {
+      if (!interruptModeEnabled) {
+        setInterruptModeEnabled(true);
+        addItem(
+          { type: MessageType.INFO, text: 'Interrupt mode enabled.' },
+          Date.now(),
+        );
+      }
     } else if (key.ctrl && input === 's' && !enteringConstrainHeightMode) {
       setConstrainHeight(false);
     }

--- a/packages/cli/src/ui/components/Help.tsx
+++ b/packages/cli/src/ui/components/Help.tsx
@@ -141,6 +141,12 @@ export const Help: React.FC<Help> = ({ commands }) => (
     </Text>
     <Text color={Colors.Foreground}>
       <Text bold color={Colors.AccentPurple}>
+        Ctrl+N
+      </Text>{' '}
+      - Enable interrupt mode
+    </Text>
+    <Text color={Colors.Foreground}>
+      <Text bold color={Colors.AccentPurple}>
         Enter
       </Text>{' '}
       - Send message


### PR DESCRIPTION
## Summary
- allow enabling interrupt mode at runtime with Ctrl+N
- document new shortcut in help screen and keyboard shortcuts
- test that Ctrl+N activates interrupt mode

## Testing
- `http_proxy='' https_proxy='' HTTP_PROXY='' HTTPS_PROXY='' npm test --workspace @google/gemini-cli` *(fails: ENOENT: no such file or directory, open '/workspace/gemini-cli-interrupt/packages/cli/coverage/.tmp/coverage-63.json')*

------
https://chatgpt.com/codex/tasks/task_e_68912b61c8988329b459209bfd6e5e72