### PR TITLE
feat: toggle interrupt mode indicator

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -14,8 +14,8 @@ This document lists the available keyboard shortcuts in the Gemini CLI.
 | `Ctrl+S` | Allows long responses to print fully, disabling truncation. Use your terminal's scrollback to view the entire output. |
 | `Ctrl+T` | Toggle the display of tool descriptions.                                                                              |
 | `Ctrl+Y` | Toggle auto-approval (YOLO mode) for all tool calls.                                                                  |
-| `Ctrl+N` | Enable interrupt mode. |
-        |
+| `Ctrl+N` | Toggle interrupt mode.                                                                                                |
+|  |
 
 ## Input Prompt
 

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -1058,7 +1058,7 @@ describe('App UI', () => {
   });
 
   describe('interrupt mode', () => {
-    it('should enable interrupt mode with Ctrl+N', async () => {
+    it('should toggle interrupt mode with Ctrl+N', async () => {
       const { stdin, lastFrame, unmount } = render(
         <App
           config={mockConfig as unknown as ServerConfig}
@@ -1077,7 +1077,20 @@ describe('App UI', () => {
 
       // Verify that useGeminiStream is called with interrupt mode enabled
       expect(vi.mocked(useGeminiStream).mock.calls.at(-1)?.[12]).toBe(true);
-      expect(lastFrame()).toContain('Interrupt mode enabled.');
+      expect(lastFrame()).toContain(
+        'interrupt mode enabled (ctrl+n to disable)',
+      );
+
+      // Send Ctrl+N again to disable interrupt mode.
+      stdin.write('\u000e');
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Verify that useGeminiStream is called with interrupt mode disabled
+      expect(vi.mocked(useGeminiStream).mock.calls.at(-1)?.[12]).toBe(false);
+      expect(lastFrame()).toContain('Interrupt mode disabled.');
+      expect(lastFrame()).not.toContain(
+        'interrupt mode enabled (ctrl+n to disable)',
+      );
     });
   });
 });

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -30,6 +30,7 @@ import { Header } from './components/Header.js';
 import { LoadingIndicator } from './components/LoadingIndicator.js';
 import { AutoAcceptIndicator } from './components/AutoAcceptIndicator.js';
 import { ShellModeIndicator } from './components/ShellModeIndicator.js';
+import { InterruptModeIndicator } from './components/InterruptModeIndicator.js';
 import { InputPrompt } from './components/InputPrompt.js';
 import { Footer } from './components/Footer.js';
 import { ThemeDialog } from './components/ThemeDialog.js';
@@ -601,13 +602,17 @@ const App = ({
       }
       handleExit(ctrlDPressedOnce, setCtrlDPressedOnce, ctrlDTimerRef);
     } else if (key.ctrl && (input === 'n' || input === 'N')) {
-      if (!interruptModeEnabled) {
-        setInterruptModeEnabled(true);
-        addItem(
-          { type: MessageType.INFO, text: 'Interrupt mode enabled.' },
-          Date.now(),
-        );
-      }
+      const newValue = !interruptModeEnabled;
+      setInterruptModeEnabled(newValue);
+      addItem(
+        {
+          type: MessageType.INFO,
+          text: newValue
+            ? 'Interrupt mode enabled.'
+            : 'Interrupt mode disabled.',
+        },
+        Date.now(),
+      );
     } else if (key.ctrl && input === 's' && !enteringConstrainHeightMode) {
       setConstrainHeight(false);
     }
@@ -990,6 +995,9 @@ const App = ({
                         approvalMode={showAutoAcceptIndicator}
                       />
                     )}
+                  {interruptModeEnabled && !shellModeActive && (
+                    <InterruptModeIndicator />
+                  )}
                   {shellModeActive && <ShellModeIndicator />}
                 </Box>
               </Box>

--- a/packages/cli/src/ui/components/Help.tsx
+++ b/packages/cli/src/ui/components/Help.tsx
@@ -143,7 +143,7 @@ export const Help: React.FC<Help> = ({ commands }) => (
       <Text bold color={Colors.AccentPurple}>
         Ctrl+N
       </Text>{' '}
-      - Enable interrupt mode
+      - Toggle interrupt mode
     </Text>
     <Text color={Colors.Foreground}>
       <Text bold color={Colors.AccentPurple}>

--- a/packages/cli/src/ui/components/InterruptModeIndicator.tsx
+++ b/packages/cli/src/ui/components/InterruptModeIndicator.tsx
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+import { Colors } from '../colors.js';
+
+export const InterruptModeIndicator: React.FC = () => (
+  <Box>
+    <Text color={Colors.AccentYellow}>
+      interrupt mode enabled
+      <Text color={Colors.Gray}> (ctrl+n to disable)</Text>
+    </Text>
+  </Box>
+);


### PR DESCRIPTION
## Summary
- allow interrupt mode to toggle on/off with Ctrl+N
- show on-screen indicator when interrupt mode is active
- document interrupt mode toggle shortcut

## Testing
- `npm test --workspace packages/cli` *(fails: Failed to resolve entry for package "@google/gemini-cli-core")*


------
https://chatgpt.com/codex/tasks/task_e_689140a11a3c83298e481de5a171bf12