### PR TITLE
feat: summarize new prompt when interrupted

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -14,7 +14,7 @@ This document lists the available keyboard shortcuts in the Gemini CLI.
 | `Ctrl+S` | Allows long responses to print fully, disabling truncation. Use your terminal's scrollback to view the entire output. |
 | `Ctrl+T` | Toggle the display of tool descriptions.                                                                              |
 | `Ctrl+Y` | Toggle auto-approval (YOLO mode) for all tool calls.                                                                  |
-| `Ctrl+N` | Toggle interrupt mode.                                                                                                |
+| `Ctrl+N` | Toggle interrupt mode. When enabled, a new prompt during a response cancels the stream and shows a brief fast-model summary of the new request.
 |  |
 
 ## Input Prompt

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -38,12 +38,14 @@ const mockSendMessageStream = vi
   .mockReturnValue((async function* () {})());
 const mockStartChat = vi.fn();
 
+const mockGenerateContent = vi.fn();
 const MockedGeminiClientClass = vi.hoisted(() =>
   vi.fn().mockImplementation(function (this: any, _config: any) {
     // _config
     this.startChat = mockStartChat;
     this.sendMessageStream = mockSendMessageStream;
     this.addHistory = vi.fn();
+    this.generateContent = mockGenerateContent;
   }),
 );
 
@@ -954,6 +956,9 @@ describe('useGeminiStream', () => {
       })();
       mockSendMessageStream.mockReturnValueOnce(mockStream1);
       mockSendMessageStream.mockReturnValueOnce(mockStream2);
+      mockGenerateContent.mockResolvedValueOnce({
+        candidates: [{ content: { parts: [{ text: 'summary text' }] } }],
+      });
 
       const { result } = renderTestHook([], undefined, true);
 
@@ -976,8 +981,8 @@ describe('useGeminiStream', () => {
       await waitFor(() => {
         expect(mockAddItem).toHaveBeenCalledWith(
           {
-            type: MessageType.INFO,
-            text: 'Stream interrupted. Awaiting new input.',
+            type: MessageType.GEMINI,
+            text: expect.stringContaining('First let\'s deal with this user demand: second query.'),
           },
           expect.any(Number),
         );

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -27,7 +27,12 @@ import {
   UserPromptEvent,
   DEFAULT_GEMINI_FLASH_MODEL,
 } from '@google/gemini-cli-core';
-import { type Part, type PartListUnion, FinishReason } from '@google/genai';
+import {
+  type Part,
+  type PartListUnion,
+  type GenerateContentResponse,
+  FinishReason,
+} from '@google/genai';
 import {
   StreamingState,
   HistoryItem,
@@ -66,6 +71,43 @@ export function mergePartListUnions(list: PartListUnion[]): PartListUnion {
     }
   }
   return resultParts;
+}
+
+function partListToString(value: PartListUnion): string {
+  if (!value) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => partListToString(v)).join('');
+  }
+  return (value as Part).text ?? '';
+}
+
+function extractTextFromResponse(response: GenerateContentResponse): string {
+  return (
+    response.candidates?.[0]?.content?.parts
+      ?.map((p: Part) => p.text ?? '')
+      .join('') ?? ''
+  );
+}
+
+function historyToContext(history: HistoryItem[], limit = 500): string {
+  const segments: string[] = [];
+  for (let i = history.length - 1; i >= 0; i--) {
+    const item = history[i];
+    if (!item.text) continue;
+    const role =
+      item.type === 'user' || item.type === 'user_shell' ? 'User' : 'Model';
+    segments.unshift(`${role}: ${item.text}`);
+    if (segments.join('\n').length > limit) {
+      break;
+    }
+  }
+  const context = segments.join('\n');
+  return context.slice(Math.max(0, context.length - limit));
 }
 
 enum StreamProcessingStatus {
@@ -181,6 +223,27 @@ export const useGeminiStream = (
     }
     return StreamingState.Idle;
   }, [isResponding, toolCalls]);
+
+  const summarizeInterruption = useCallback(
+    async (query: PartListUnion) => {
+      const queryText = partListToString(query);
+      const context = historyToContext(history);
+      const prompt = `In context of the conversation:\n${context}\n\nUser request: ${queryText}\n\nBriefly explain what the user wants.`;
+      try {
+        const response = await geminiClient.generateContent(
+          [{ role: 'user', parts: [{ text: prompt }] }],
+          {},
+          new AbortController().signal,
+          DEFAULT_GEMINI_FLASH_MODEL,
+        );
+        const explanation = extractTextFromResponse(response).trim();
+        return `First let's deal with this user demand: ${queryText}. ${explanation}`;
+      } catch {
+        return `First let's deal with this user demand: ${queryText}.`;
+      }
+    },
+    [geminiClient, history],
+  );
 
   useInput((_input, key) => {
     if (streamingState === StreamingState.Responding && key.escape) {
@@ -629,12 +692,14 @@ export const useGeminiStream = (
       options?: { isContinuation: boolean },
       prompt_id?: string,
     ) => {
+      let wasInterrupted = false;
       if (
         (streamingState === StreamingState.Responding ||
           streamingState === StreamingState.WaitingForConfirmation) &&
         !options?.isContinuation
       ) {
         if (interruptMode) {
+          wasInterrupted = true;
           turnCancelledRef.current = true;
           abortControllerRef.current?.abort();
           if (pendingHistoryItemRef.current) {
@@ -648,13 +713,6 @@ export const useGeminiStream = (
             }
             setPendingHistoryItem(null);
           }
-          addItem(
-            {
-              type: MessageType.INFO,
-              text: 'Stream interrupted. Awaiting new input.',
-            },
-            Date.now(),
-          );
           setIsResponding(false);
         } else {
           return;
@@ -686,6 +744,11 @@ export const useGeminiStream = (
 
       if (!shouldProceed || queryToSend === null) {
         return;
+      }
+
+      if (wasInterrupted) {
+        const summary = await summarizeInterruption(query);
+        addItem({ type: MessageType.GEMINI, text: summary }, Date.now());
       }
 
       if (!options?.isContinuation) {
@@ -757,6 +820,7 @@ export const useGeminiStream = (
       startNewPrompt,
       getPromptCount,
       handleLoopDetectedEvent,
+      summarizeInterruption,
       interruptMode,
     ],
   );


### PR DESCRIPTION
## Summary
- intercept new prompts entered while streaming and summarize them with a fast model before continuing
- note the interrupt-mode behavior in docs
- adjust tests for new interrupt flow

## Testing
- `npm test` *(fails: Failed to resolve entry for package "@google/gemini-cli-core"...)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68915bdda19c8329ad6a786afe47c2fa