### PR TITLE
feat(cli): memoize plan sidebar to reduce flicker

### DIFF
--- a/packages/cli/src/ui/components/PlanSidebar.tsx
+++ b/packages/cli/src/ui/components/PlanSidebar.tsx
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { memo } from 'react';
 import { Box, Text } from 'ink';
 import { usePlan } from '../contexts/PlanContext.js';
 import { Colors } from '../colors.js';
 
-const ProgressBar = ({ progress }: { progress: number }) => {
+function ProgressBarComponent({ progress }: { progress: number }) {
   const width = 20;
   const completed = Math.round(width * progress);
   const remaining = width - completed;
@@ -18,9 +19,11 @@ const ProgressBar = ({ progress }: { progress: number }) => {
       {'.'.repeat(remaining)}] {Math.round(progress * 100)}%
     </Text>
   );
-};
+}
 
-export const PlanSidebar = ({ width = 30 }: { width?: number }) => {
+const ProgressBar = memo(ProgressBarComponent);
+
+function PlanSidebarComponent({ width = 30 }: { width?: number }) {
   const { steps, currentStep } = usePlan();
   if (!steps.length) {
     return null;
@@ -46,4 +49,6 @@ export const PlanSidebar = ({ width = 30 }: { width?: number }) => {
       ))}
     </Box>
   );
-};
+}
+
+export const PlanSidebar = memo(PlanSidebarComponent);


### PR DESCRIPTION
## Summary
- memoize PlanSidebar and its progress bar so only the sidebar re-renders when plan data changes

## Testing
- `npm run lint -w packages/cli`
- `npm test -w packages/cli` *(fails: Failed to resolve entry for package "@google/gemini-cli-core")*


------
https://chatgpt.com/codex/tasks/task_e_6891c260c5ec832994f549b076f53130