### PR TITLE
build: generate commit info before compiling

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,7 @@
     "gemini": "dist/index.js"
   },
   "scripts": {
-    "build": "node ../../scripts/build_package.js",
+    "build": "node ../../scripts/generate-git-commit-info.js && node ../../scripts/build_package.js",
     "start": "node dist/index.js",
     "debug": "node --inspect-brk dist/index.js",
     "lint": "eslint . --ext .ts,.tsx",


### PR DESCRIPTION
## Summary
- ensure git commit metadata is generated before running TypeScript build for CLI

## Testing
- `npm install`
- `npm test` *(fails: AssertionError in vitest run for @google/gemini-cli@0.1.16 and @google/gemini-cli-core@0.1.16)*

------
https://chatgpt.com/codex/tasks/task_e_68921e4d18d483298d7ab0ca47688704