### PR TITLE
fix: skip bundling on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "format": "prettier --write .",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "preflight": "npm run clean && npm ci && npm run format && npm run lint:ci && npm run build && npm run typecheck && npm run test:ci",
-    "prepare": "npm run bundle",
+    "prepack": "npm run bundle",
     "prepare:package": "node scripts/prepare-package.js",
     "release:version": "node scripts/version.js",
     "telemetry": "node scripts/telemetry.js",


### PR DESCRIPTION
## Summary
- avoid running bundle script on install by using `prepack` instead of `prepare`

## Testing
- `npm test` *(fails: runNonInteractive should process input and write text output, others)*

------
https://chatgpt.com/codex/tasks/task_e_6892b853542c83298b37911c24004249