### PR TITLE
build: ensure package build before publish

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,8 @@
     "test": "vitest run",
     "test:ci": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "prepack": "npm run build"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary
- build CLI package before packing to ensure dist files are included

## Testing
- `npm test --workspace packages/cli` *(fails: Test Files 2 failed | 17 passed)*
- `npm run lint --workspace packages/cli` *(fails: 3 errors, no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_6892bd496a508329ad426aa32ae9a3fc