### PR TITLE
fix(cli): use versioned core dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11840,7 +11840,7 @@
       "name": "@google/gemini-cli",
       "version": "0.1.16",
       "dependencies": {
-        "@google/gemini-cli-core": "file:../core",
+        "@google/gemini-cli-core": "^0.1.16",
         "@google/genai": "1.9.0",
         "@iarna/toml": "^2.2.5",
         "@types/update-notifier": "^6.0.8",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
     "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.16"
   },
   "dependencies": {
-    "@google/gemini-cli-core": "file:../core",
+    "@google/gemini-cli-core": "^0.1.16",
     "@google/genai": "1.9.0",
     "@iarna/toml": "^2.2.5",
     "@types/update-notifier": "^6.0.8",


### PR DESCRIPTION
## Summary
- reference the published `@google/gemini-cli-core` package using a semver range instead of a local file path

## Testing
- `npm test --workspace packages/cli` *(fails: 2 failed test files, 20 failed tests)*
- `npm test --workspace packages/core`


------
https://chatgpt.com/codex/tasks/task_e_6892bd496a508329ad426aa32ae9a3fc