### PR TITLE
docs: update install link and fix merge leftovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ You have two options to install Gemini CLI.
 2. **Run the CLI:** Execute the following command in your terminal:
 
    ```bash
-   npx https://github.com/google-gemini/gemini-cli-interrupt
+   npx https://github.com/damdam775/gemini-cli-interrupt
    ```
 
    Add `--interrupt` to launch with interrupt mode already enabled:
 
    ```bash
-   npx https://github.com/google-gemini/gemini-cli-interrupt -- --interrupt
+   npx https://github.com/damdam775/gemini-cli-interrupt -- --interrupt
    ```
 
    Or install it with:

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -65,11 +65,8 @@ export interface CliArgs {
   ideModeFeature: boolean | undefined;
   proxy: string | undefined;
   includeDirectories: string[] | undefined;
- codex/update-readme-for-interrupt-mode-installation
   interrupt?: boolean | undefined;
-=======
   loadMemoryFromIncludeDirectories: boolean | undefined;
- main
 }
 
 export async function parseArguments(): Promise<CliArgs> {

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -519,11 +519,8 @@ const App = ({
     performMemoryRefresh,
     modelSwitchedFromQuotaError,
     setModelSwitchedFromQuotaError,
- codex/update-readme-for-interrupt-mode-installation
     interruptModeEnabled,
-=======
     refreshStatic,
- main
   );
 
   // Input handling

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -136,11 +136,8 @@ export const useGeminiStream = (
   performMemoryRefresh: () => Promise<void>,
   modelSwitchedFromQuotaError: boolean,
   setModelSwitchedFromQuotaError: React.Dispatch<React.SetStateAction<boolean>>,
- codex/update-readme-for-interrupt-mode-installation
   interruptMode = false,
-=======
-  onEditorClose: () => void,
- main
+  onEditorClose: () => void = () => {},
 ) => {
   const [initError, setInitError] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);


### PR DESCRIPTION
## Summary
- fix README Node install instructions to point to fork
- clean up merge leftovers and support interrupt mode with editor close hook

## Testing
- `npm test` *(fails: Failed to resolve entry for package "@google/gemini-cli-core"; 1 test failed)*

------
https://chatgpt.com/codex/tasks/task_e_6892edc673d88329bd657804b6faf55e