### PR TITLE
feat: improve plan sidebar and interruption flow

### DIFF
--- a/packages/cli/src/ui/components/PlanSidebar.tsx
+++ b/packages/cli/src/ui/components/PlanSidebar.tsx
@@ -21,7 +21,7 @@ const ProgressBar = ({ progress }: { progress: number }) => {
 };
 
 export const PlanSidebar = ({ width = 30 }: { width?: number }) => {
-  const { steps, currentStep } = usePlan();
+  const { steps, currentStep, rules } = usePlan();
   if (!steps.length) {
     return null;
   }
@@ -44,6 +44,14 @@ export const PlanSidebar = ({ width = 30 }: { width?: number }) => {
           <ProgressBar progress={step.progress} />
         </Box>
       ))}
+      {rules.length > 0 && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={Colors.AccentBlue}>Rules</Text>
+          {rules.map((rule, idx) => (
+            <Text key={idx}>- {rule}</Text>
+          ))}
+        </Box>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- show detailed steps and user rules in the sidebar
- generate plan steps from user queries and persist rules
- classify interruptions to continue, queries, rules, or replan

## Testing
- `npm test --workspace packages/cli` *(fails: Failed to resolve entry for package "@google/gemini-cli-core")*

------
https://chatgpt.com/codex/tasks/task_e_6892f3388c5c8329aa9422e020e78ec8