### PR TITLE
feat: add human-in-the-loop tool and command

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.test.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.test.ts
@@ -41,6 +41,7 @@ vi.mock('../ui/commands/extensionsCommand.js', () => ({
 }));
 vi.mock('../ui/commands/helpCommand.js', () => ({ helpCommand: {} }));
 vi.mock('../ui/commands/memoryCommand.js', () => ({ memoryCommand: {} }));
+vi.mock('../ui/commands/humanCommand.js', () => ({ humanCommand: {} }));
 vi.mock('../ui/commands/privacyCommand.js', () => ({ privacyCommand: {} }));
 vi.mock('../ui/commands/quitCommand.js', () => ({ quitCommand: {} }));
 vi.mock('../ui/commands/statsCommand.js', () => ({ statsCommand: {} }));

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -32,6 +32,7 @@ import { themeCommand } from '../ui/commands/themeCommand.js';
 import { toolsCommand } from '../ui/commands/toolsCommand.js';
 import { vimCommand } from '../ui/commands/vimCommand.js';
 import { setupGithubCommand } from '../ui/commands/setupGithubCommand.js';
+import { humanCommand } from '../ui/commands/humanCommand.js';
 import { isGitHubRepository } from '../utils/gitUtils.js';
 
 /**
@@ -67,6 +68,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       initCommand,
       mcpCommand,
       memoryCommand,
+      humanCommand,
       privacyCommand,
       quitCommand,
       restoreCommand(this.config),

--- a/packages/cli/src/ui/commands/humanCommand.test.ts
+++ b/packages/cli/src/ui/commands/humanCommand.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { humanCommand } from './humanCommand.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { MessageType } from '../types.js';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+describe('humanCommand', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'human-cmd-'));
+    process.chdir(tmpDir);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+  });
+
+  it('writes guidance to rules.json', async () => {
+    const ctx = createMockCommandContext({});
+    await humanCommand.action!(ctx, 'stay focused');
+    const data = await fs.readFile(path.join(tmpDir, 'rules.json'), 'utf8');
+    expect(JSON.parse(data)).toEqual(['stay focused']);
+  });
+
+  it('shows usage message when no args provided', async () => {
+    const ctx = createMockCommandContext({});
+    await humanCommand.action!(ctx, '');
+    expect(ctx.ui.addItem).toHaveBeenCalledWith(
+      { type: MessageType.ERROR, text: 'Usage: /human <guidance>' },
+      expect.any(Number),
+    );
+  });
+});

--- a/packages/cli/src/ui/commands/humanCommand.ts
+++ b/packages/cli/src/ui/commands/humanCommand.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import { CommandKind, SlashCommand } from './types.js';
+import { MessageType } from '../types.js';
+
+/**
+ * Records human guidance by appending it to rules.json.
+ */
+export const humanCommand: SlashCommand = {
+  name: 'human',
+  description: 'add human rule or direction',
+  kind: CommandKind.BUILT_IN,
+  action: async (context, args) => {
+    const rule = args?.trim();
+    if (!rule) {
+      context.ui.addItem(
+        { type: MessageType.ERROR, text: 'Usage: /human <guidance>' },
+        Date.now(),
+      );
+      return;
+    }
+    const rulesFile = path.join(process.cwd(), 'rules.json');
+    let rules: string[] = [];
+    try {
+      const data = await fs.readFile(rulesFile, 'utf8');
+      rules = JSON.parse(data);
+    } catch {
+      // file may not exist
+    }
+    rules.push(rule);
+    await fs.writeFile(rulesFile, JSON.stringify(rules, null, 2));
+    context.ui.addItem(
+      { type: MessageType.INFO, text: `Added rule: "${rule}"` },
+      Date.now(),
+    );
+  },
+};

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -70,6 +70,7 @@ export const Footer: React.FC<FooterProps> = ({
             {' ' + (debugMessage || '--debug')}
           </Text>
         )}
+        <Text color={Colors.Gray}> | /human</Text>
       </Box>
 
       {/* Middle Section: Centered Sandbox Info */}

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -63,6 +63,7 @@ vi.mock('../tools/memoryTool', () => ({
   DEFAULT_CONTEXT_FILENAME: 'GEMINI.md',
   GEMINI_CONFIG_DIR: '.gemini',
 }));
+vi.mock('../tools/human-loop');
 
 vi.mock('../core/contentGenerator.js', async (importOriginal) => {
   const actual =

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -28,6 +28,7 @@ import {
   GEMINI_CONFIG_DIR as GEMINI_DIR,
 } from '../tools/memoryTool.js';
 import { WebSearchTool } from '../tools/web-search.js';
+import { HumanLoopTool } from '../tools/human-loop.js';
 import { GeminiClient } from '../core/client.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { GitService } from '../services/gitService.js';
@@ -715,6 +716,7 @@ export class Config {
     registerCoreTool(ShellTool, this);
     registerCoreTool(MemoryTool);
     registerCoreTool(WebSearchTool, this);
+    registerCoreTool(HumanLoopTool);
 
     await registry.discoverAllTools();
     return registry;

--- a/packages/core/src/tools/human-loop.test.ts
+++ b/packages/core/src/tools/human-loop.test.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { HumanLoopTool } from './human-loop.js';
+
+describe('HumanLoopTool', () => {
+  it('validates presence of prompt', () => {
+    const tool = new HumanLoopTool();
+    // @ts-expect-error testing invalid params
+    expect(tool.validateToolParams({})).toMatch(/prompt/);
+    expect(tool.validateToolParams({ prompt: 'hi' })).toBeNull();
+  });
+
+  it('returns provided response without prompting', async () => {
+    const tool = new HumanLoopTool();
+    const result = await tool.execute({ prompt: 'Say', response: 'hello' });
+    expect(result.llmContent).toBe('hello');
+    expect(result.returnDisplay).toBe('hello');
+  });
+});

--- a/packages/core/src/tools/human-loop.ts
+++ b/packages/core/src/tools/human-loop.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import readline from 'readline';
+import { BaseTool, Icon, ToolResult } from './tools.js';
+
+interface HumanLoopParams {
+  /**
+   * Prompt to display to the user when requesting guidance.
+   */
+  prompt: string;
+  /**
+   * Optional predefined response, useful for tests or non-interactive environments.
+   */
+  response?: string;
+}
+
+/**
+ * A tool that allows the model to request human guidance at any time.
+ * If a response is not provided, the tool will prompt on stdin.
+ */
+export class HumanLoopTool extends BaseTool<HumanLoopParams> {
+  static readonly Name = 'human_loop';
+  constructor() {
+    super(
+      HumanLoopTool.Name,
+      'Human in the loop',
+      'Request direction or advice from the user.',
+      Icon.LightBulb,
+      {
+        type: 'object',
+        properties: {
+          prompt: { type: 'string' },
+          response: { type: 'string' },
+        },
+        required: ['prompt'],
+      },
+      false,
+      false,
+    );
+  }
+
+  validateToolParams(params: HumanLoopParams): string | null {
+    if (!params.prompt || typeof params.prompt !== 'string') {
+      return 'Missing "prompt" parameter';
+    }
+    return null;
+  }
+
+  async execute(params: HumanLoopParams): Promise<ToolResult> {
+    let answer = params.response;
+    if (answer === undefined) {
+      const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+      });
+      answer = await new Promise<string>((resolve) => {
+        rl.question(`${params.prompt} `, (resp) => {
+          rl.close();
+          resolve(resp);
+        });
+      });
+    }
+    return {
+      llmContent: answer,
+      returnDisplay: answer,
+    };
+  }
+
+  getDescription(params: HumanLoopParams): string {
+    return `Ask human: ${params.prompt}`;
+  }
+}
+
+export default HumanLoopTool;


### PR DESCRIPTION
## Summary
- implement `HumanLoopTool` for prompting user guidance
- add `/human` command to append guidance to `rules.json`
- display `/human` hint in footer

## Testing
- `npm test` *(fails: Failed to resolve entry for package "@google/gemini-cli-core")*

------
https://chatgpt.com/codex/tasks/task_e_68939a8eb6bc83298868b3326ca98ebe