### PR TITLE
feat: improve user prompts and planning

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -126,7 +126,8 @@ const App = ({
   const { stdout } = useStdout();
   const nightly = version.includes('nightly');
   const { history, addItem, clearItems, loadHistory } = useHistory();
-  const { planHistory, currentPlanIndex, switchPlan } = usePlan();
+  const { planHistory, currentPlanIndex, switchPlan, confirmPlan, planConfirmed } =
+    usePlan();
 
   useEffect(() => {
     const cleanup = setUpdateHandler(addItem, setUpdateInfo);
@@ -629,12 +630,26 @@ const App = ({
     } else if (key.shift && key.rightArrow) {
       const newIndex = Math.min(planHistory.length - 1, currentPlanIndex + 1);
       switchPlan(newIndex);
-    } else if (!key.ctrl && !key.meta && ['1', '2', '3', '4'].includes(input)) {
-      const idx = Number(input) - 1;
-      switchPlan(idx);
-    } else if (key.ctrl && input === 's' && !enteringConstrainHeightMode) {
-      setConstrainHeight(false);
-    }
+      } else if (!key.ctrl && !key.meta && ['1', '2', '3', '4'].includes(input)) {
+        const idx = Number(input) - 1;
+        switchPlan(idx);
+      } else if (
+        key.return &&
+        planHistory.length > 0 &&
+        !planConfirmed &&
+        buffer.text.length === 0
+      ) {
+        confirmPlan();
+        addItem(
+          {
+            type: MessageType.INFO,
+            text: `Plan ${currentPlanIndex + 1} confirmed.`,
+          },
+          Date.now(),
+        );
+      } else if (key.ctrl && input === 's' && !enteringConstrainHeightMode) {
+        setConstrainHeight(false);
+      }
   });
 
   useEffect(() => {

--- a/packages/cli/src/ui/commands/initCommand.ts
+++ b/packages/cli/src/ui/commands/initCommand.ts
@@ -92,7 +92,7 @@ Write the complete content to the \`GEMINI.md\` file. The output must be well-fo
 
 ${userRequest ? `\n**User Request:** ${userRequest}\n` : ''}
 
-Before writing, perform a brief web search for libraries, tools, or techniques relevant to this request. Identify MCP servers, external tools, and dependencies that could help. Draft a plan with high-level goals split into parts, each with steps and suggested alternative approaches. Record alternate plans where appropriate.
+Before writing, perform a brief web search for libraries, tools, or techniques relevant to this request. Identify MCP servers, external tools, and dependencies that could help. Draft a primary plan along with at least one alternate plan option, outlining high-level goals split into parts with steps and suggested tools or libraries. Clearly label each plan and record alternate approaches where appropriate.
 `,
     };
   },

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -65,7 +65,9 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
         terminalWidth={terminalWidth}
       />
     )}
-    {item.type === 'info' && <InfoMessage text={item.text} />}
+    {item.type === 'info' && (
+      <InfoMessage text={item.text} isInterrupt={item.isInterrupt} />
+    )}
     {item.type === 'error' && <ErrorMessage text={item.text} />}
     {item.type === 'about' && (
       <AboutBox

--- a/packages/cli/src/ui/components/messages/InfoMessage.tsx
+++ b/packages/cli/src/ui/components/messages/InfoMessage.tsx
@@ -10,19 +10,24 @@ import { Colors } from '../../colors.js';
 
 interface InfoMessageProps {
   text: string;
+  isInterrupt?: boolean;
 }
 
-export const InfoMessage: React.FC<InfoMessageProps> = ({ text }) => {
+export const InfoMessage: React.FC<InfoMessageProps> = ({
+  text,
+  isInterrupt = false,
+}) => {
   const prefix = 'ℹ ';
   const prefixWidth = prefix.length;
+  const color = isInterrupt ? Colors.AccentRed : Colors.AccentYellow;
 
   return (
     <Box flexDirection="row" marginTop={1}>
       <Box width={prefixWidth}>
-        <Text color={Colors.AccentYellow}>{prefix}</Text>
+        <Text color={color}>{prefix}</Text>
       </Box>
       <Box flexGrow={1}>
-        <Text wrap="wrap" color={Colors.AccentYellow}>
+        <Text wrap="wrap" color={color}>
           {text}
         </Text>
       </Box>

--- a/packages/cli/src/ui/components/messages/UserMessage.tsx
+++ b/packages/cli/src/ui/components/messages/UserMessage.tsx
@@ -25,12 +25,12 @@ export const UserMessage: React.FC<UserMessageProps> = ({
     ? Colors.AccentPurple
     : isInterrupt
       ? Colors.AccentYellow
-      : Colors.Gray;
+      : Colors.AccentGreen;
   const borderColor = isSlashCommand
     ? Colors.AccentPurple
     : isInterrupt
       ? Colors.AccentYellow
-      : Colors.Gray;
+      : Colors.AccentGreen;
 
   return (
     <Box

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -297,15 +297,16 @@ export const useGeminiStream = (
       if (pendingHistoryItemRef.current) {
         addItem(pendingHistoryItemRef.current, Date.now());
       }
-      addItem(
-        {
-          type: MessageType.INFO,
-          text: interruptMode
-            ? 'Stream interrupted. Awaiting new input.'
-            : 'Request cancelled.',
-        },
-        Date.now(),
-      );
+        addItem(
+          {
+            type: MessageType.INFO,
+            text: interruptMode
+              ? 'Stream interrupted. Awaiting new input.'
+              : 'Request cancelled.',
+            isInterrupt: true,
+          },
+          Date.now(),
+        );
       setPendingHistoryItem(null);
       setIsResponding(false);
     }
@@ -533,10 +534,14 @@ export const useGeminiStream = (
         }
         setPendingHistoryItem(null);
       }
-      addItem(
-        { type: MessageType.INFO, text: 'User cancelled the request.' },
-        userMessageTimestamp,
-      );
+        addItem(
+          {
+            type: MessageType.INFO,
+            text: 'User cancelled the request.',
+            isInterrupt: true,
+          },
+          userMessageTimestamp,
+        );
       setIsResponding(false);
       setThought(null); // Reset thought when user cancels
     },
@@ -742,9 +747,13 @@ export const useGeminiStream = (
         switch (intent) {
           case InterruptionCategory.Continue:
             addItem(
-              { type: MessageType.INFO, text: 'Continuing with current plan.' },
+              {
+                type: MessageType.INFO,
+                text: 'Continuing with current plan.',
+                isInterrupt: true,
+              },
               Date.now(),
-            );
+              );
             return;
           case InterruptionCategory.StatusQuery:
             addItem(
@@ -761,9 +770,13 @@ export const useGeminiStream = (
           case InterruptionCategory.Rule:
             addRule(queryText);
             addItem(
-              { type: MessageType.INFO, text: `Rule noted: ${queryText}` },
+              {
+                type: MessageType.INFO,
+                text: `Rule noted: ${queryText}`,
+                isInterrupt: true,
+              },
               Date.now(),
-            );
+              );
             return;
           case InterruptionCategory.Replan:
             if (interruptMode) {

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -81,6 +81,7 @@ export type HistoryItemGeminiContent = HistoryItemBase & {
 export type HistoryItemInfo = HistoryItemBase & {
   type: 'info';
   text: string;
+  isInterrupt?: boolean;
 };
 
 export type HistoryItemError = HistoryItemBase & {


### PR DESCRIPTION
## Summary
- highlight user queries in bright green and show interrupt info in red for clearer CLI feedback
- update `init` command prompt to accept an initial request and suggest tools with alternate plans
- allow previewing and confirming multiple plan options using Shift+arrows, number keys or Enter

## Testing
- `npm run lint --workspace=@google/gemini-cli`
- `npm test --workspace packages/cli` *(partial run; tests executed before runner stalled)*

------
https://chatgpt.com/codex/tasks/task_e_68951a6a2fdc8329aefa50535131dba9